### PR TITLE
Some simple UI fixes

### DIFF
--- a/assets/questions/A.json
+++ b/assets/questions/A.json
@@ -643,7 +643,7 @@
                         {
                             "number": "AA112",
                             "class": "3",
-                            "question": "Der Pegelwert 120 dB$\u03bc$V/m entspricht einer elektrischen Feldst\u00e4rke von ...",
+                            "question": "Der Pegelwert 120 dB\u03bcV/m entspricht einer elektrischen Feldst\u00e4rke von ...",
                             "answer_a": "1 V/m.",
                             "answer_b": "0,78 V/m.",
                             "answer_c": "41,6 V/m.",

--- a/assets/questions/EA.json
+++ b/assets/questions/EA.json
@@ -1666,7 +1666,7 @@
                         {
                             "number": "AA112",
                             "class": "3",
-                            "question": "Der Pegelwert 120 dB$\u03bc$V/m entspricht einer elektrischen Feldst\u00e4rke von ...",
+                            "question": "Der Pegelwert 120 dB\u03bcV/m entspricht einer elektrischen Feldst\u00e4rke von ...",
                             "answer_a": "1 V/m.",
                             "answer_b": "0,78 V/m.",
                             "answer_c": "41,6 V/m.",

--- a/assets/questions/NEA.json
+++ b/assets/questions/NEA.json
@@ -4829,7 +4829,7 @@
                         {
                             "number": "AA112",
                             "class": "3",
-                            "question": "Der Pegelwert 120 dB$\u03bc$V/m entspricht einer elektrischen Feldst\u00e4rke von ...",
+                            "question": "Der Pegelwert 120 dB\u03bcV/m entspricht einer elektrischen Feldst\u00e4rke von ...",
                             "answer_a": "1 V/m.",
                             "answer_b": "0,78 V/m.",
                             "answer_c": "41,6 V/m.",

--- a/assets/questions/Questions.json
+++ b/assets/questions/Questions.json
@@ -80,7 +80,7 @@
                                 {
                                     "number": "AA112",
                                     "class": "3",
-                                    "question": "Der Pegelwert 120 dB$\u03bc$V/m entspricht einer elektrischen Feldst\u00e4rke von ...",
+                                    "question": "Der Pegelwert 120 dB\u03bcV/m entspricht einer elektrischen Feldst\u00e4rke von ...",
                                     "answer_a": "1 V/m.",
                                     "answer_b": "0,78 V/m.",
                                     "answer_c": "41,6 V/m.",

--- a/lib/helpers/packagesListing.dart
+++ b/lib/helpers/packagesListing.dart
@@ -86,7 +86,7 @@ class MiscOssLicenseSingle extends StatelessWidget {
               Padding(
                   padding: const EdgeInsets.only(top: 12.0, left: 12.0, right: 12.0),
                   child: Text(package.description,
-                      style: Theme.of(context).textTheme.bodyText2!.copyWith(fontWeight: FontWeight.bold))),
+                      style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.bold))),
             if (package.homepage != null)
               Padding(
                   padding: const EdgeInsets.only(top: 12.0, left: 12.0, right: 12.0),
@@ -98,7 +98,7 @@ class MiscOssLicenseSingle extends StatelessWidget {
             if (package.description.isNotEmpty || package.homepage != null) const Divider(),
             Padding(
               padding: const EdgeInsets.only(top: 12.0, left: 12.0, right: 12.0),
-              child: Text(_bodyText(), style: Theme.of(context).textTheme.bodyText2),
+              child: Text(_bodyText(), style: Theme.of(context).textTheme.bodyMedium),
             ),
           ])),
     );

--- a/lib/screens/chapterSelection.dart
+++ b/lib/screens/chapterSelection.dart
@@ -204,7 +204,7 @@ class _LearningmoduleState extends State<Learningmodule> {
                       padding: const EdgeInsets.all(8.0),
                       child: Text(
                         json.chapter_names(currentmainchapter),
-                        style: Theme.of(context).textTheme.headline5,
+                        style: Theme.of(context).textTheme.headlineSmall,
                       ),
                     ),
                   ),

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -59,7 +59,7 @@ class _WelcomeState extends State<Welcome> {
                                   Text("Willkommen,", style: TextStyle(fontSize: 50, fontWeight: FontWeight.w800),),
                                   Text(
                                       "wir freuen uns dich auf deinem Weg zur Amateurfunkzulassung begleiten zu dürfen.",
-                                      style: TextStyle(fontSize: 20, color: Color.fromARGB(255, 39, 39, 39), fontWeight: FontWeight.w600)
+                                      style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600)
                                   ),
 
                                 ]

--- a/lib/style/style.dart
+++ b/lib/style/style.dart
@@ -8,7 +8,7 @@ lightmode() => ThemeData(
                 brightness: Brightness.light,
                 primaryColor: main_col,
                 textTheme: TextTheme(
-                    headline5: TextStyle(color: Colors.black, fontWeight: FontWeight.w500,)
+                    headlineSmall: TextStyle(color: Colors.black, fontWeight: FontWeight.w500,)
                 )
             );
 


### PR DESCRIPTION
- Replace deprecated theme color names (can now compile with Flutter 3.24) ([Flutter release note](https://docs.flutter.dev/release/breaking-changes/3-19-deprecations))
- Remove hard coded color in splash screen of fresh installation (text was invisible on devices with dark theme enabled)
- Fix display of "dBµV" in the question JSON's. (e.g. question AA112).
