### PR TITLE
Center chapterSelection screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@
 /packages/flutter/coverage/
 version
 analysis_benchmark.json
+devtools_options.yaml
 
 # packages file containing multi-root paths
 .packages.generated

--- a/lib/screens/chapterSelection.dart
+++ b/lib/screens/chapterSelection.dart
@@ -132,9 +132,8 @@ class _LearningmoduleState extends State<Learningmodule> {
 
   Widget selectlesson(var data, var context) {
     Json json = Json(data);
-    return ConstrainedBox(
+    return Center( child: ConstrainedBox(      
       constraints: BoxConstraints(maxWidth: 800, minWidth: 0),
-
       child: Padding(
         padding: EdgeInsets.only(left: 5,right: 5),
         child: ListView.builder(
@@ -160,7 +159,7 @@ class _LearningmoduleState extends State<Learningmodule> {
           }
         )
       ),
-    );
+    ));
   }
 
 


### PR DESCRIPTION
Chapter Selection can be unaligned when using mobile device in landscape mode:
![Unaligned](https://github.com/user-attachments/assets/2759ef27-e295-40b5-8cfa-39e028bc24d6)

This pull request is centers the chapter alignment:
![Center](https://github.com/user-attachments/assets/0e73c93f-dc38-4711-8fc5-62d872745d5b)

Particular with the 50Ohm Logo this looks better.



