### PR TITLE
Fix: Now the Button "Weiter" should be centered.

### DIFF
--- a/lib/screens/question.dart
+++ b/lib/screens/question.dart
@@ -361,7 +361,7 @@ ListView radioSvgListBuilder() {
                 ),
               SafeArea(
                 child: Padding(
-                  padding: EdgeInsets.only(bottom: 10, left: 8,),
+                  padding: EdgeInsets.only(bottom: 10, left: 8, right: 8),
                   child: ElevatedButton(
                     autofocus: false,
                     style: buttonstyle(wrong ? Colors.redAccent : Colors.green),


### PR DESCRIPTION
The button "Weiter" in the question section was not aligned.

Unalined: 
![unaligned - 2024-10-19 at 00 08 35](https://github.com/user-attachments/assets/6d6fc5df-9663-4c2e-8aa9-bbd51644c7f7)

This small fix should align the button:

![alignedSimulator Screen Shot - iPhone SE (3rd generation) - 2024-10-19 at 00 11 51](https://github.com/user-attachments/assets/b3679653-66cf-428b-b307-3e66729c961b)
