### PR TITLE
Fixing the chapter selection

### DIFF
--- a/lib/screens/chapterSelection.dart
+++ b/lib/screens/chapterSelection.dart
@@ -265,15 +265,15 @@ class _LearningmoduleState extends State<Learningmodule> {
       case [1]:
         return chapterbuilder(context, 'assets/questions/N.json', -1);
       case [1, 2]:
-        return chapterbuilder(context, 'assets/questions/E.json', -1);
-      case [1, 2, 3]:
-        return chapterbuilder(context, 'assets/questions/A.json', -1);
-      case [2]:
         return chapterbuilder(context, 'assets/questions/NE.json', -1);
-      case [3]:
-        return chapterbuilder(context, 'assets/questions/EA.json', -1);
-      case [2, 3]:
+      case [1, 2, 3]:
         return chapterbuilder(context, 'assets/questions/NEA.json', -1);
+      case [2]:
+        return chapterbuilder(context, 'assets/questions/E.json', -1);
+      case [3]:
+        return chapterbuilder(context, 'assets/questions/A.json', -1);
+      case [2, 3]:
+        return chapterbuilder(context, 'assets/questions/EA.json', -1);
 
     }
   }


### PR DESCRIPTION
The selection screens of the classes were wrong: 

When selecting the classes without any knowledge beforehand, only the questions for the corresponding class will be loaded and not the subclasses:

- "Klasse N" -> N.json 
- "Klasse E" -> E.json 
- "Klasse A" -> A.json 

This must be changed to:

- "Klasse N" -> N.json  
- "Klasse E" -> NE.json 
- "Klasse A" -> NEA.json 

When selecting the upgrades, too many classes are loaded:

- "Upgrade von N auf E" -> NE.json 
- "Upgrade von E auf A" -> EA.json 
- "Upgrade von N auf A" -> NEA.json 

This must be changed to:

- "Upgrade von N auf E" -> E.json 
- "Upgrade von E auf A" -> A.json 
- "Upgrade von N auf A" -> EA.json 

I have included below my suggested changes to fix it.

Greetings from Würzburg
Lukas