### PR TITLE
chore(pubspec): pin previous version of flutter_math_fork

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   flutter_math_fork:
     git:
       url: https://github.com/simpleclub-extended/flutter_math_fork
+      ref: 6e84b607c5c0e00dd1f3d4bd30ef3f1628053328
   package_info_plus: ^5.0.1
 
 


### PR DESCRIPTION
A previous version of flutter_math_fork needed to be pinned in order for builds to work properly.