### PR TITLE
fix: Add "Lehrmaterial" button visibility condition

### DIFF
--- a/lib/screens/question.dart
+++ b/lib/screens/question.dart
@@ -138,7 +138,7 @@ class _Questionstate extends State<Question> with TickerProviderStateMixin {
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  if (DatabaseWidget.of(context).settings_database.get("courseOrdering") ?? false)
+                  if (DatabaseWidget.of(context).settings_database.get("courseOrdering") ?? true)
                   IconButton(
                     icon: Icon(Icons.menu_book),
                     tooltip: "50Ω Lernmaterial",

--- a/lib/screens/question.dart
+++ b/lib/screens/question.dart
@@ -138,6 +138,7 @@ class _Questionstate extends State<Question> with TickerProviderStateMixin {
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
+                  if (DatabaseWidget.of(context).settings_database.get("courseOrdering") ?? false)
                   IconButton(
                     icon: Icon(Icons.menu_book),
                     tooltip: "50Ω Lernmaterial",


### PR DESCRIPTION
Fügt eine zusätzliche visibility condition für den "50Ohm Lernmaterial" Knopf hinzu, dass dieser nur sicherbar sein soll, falls nach 50Ohm Lernmaterial gelernt wird.