### PR TITLE
feat: Added basic screenreader functionality/usability

### DIFF
--- a/lib/helpers/questionsLicenseNotice.dart
+++ b/lib/helpers/questionsLicenseNotice.dart
@@ -24,16 +24,24 @@ class QuestionsLicensePage extends StatelessWidget {
             tiles: [
               SettingsTile(
                 title: Text('Bundesnetzagentur,\n 2. Auflage, Dezember 2023 \n'),
-                description: GestureDetector(
-                  onTap: () => _launchURL('https://www.bundesnetzagentur.de/amateurfunk'),
-                  child: Text('www.bundesnetzagentur.de/amateurfunk \n \n Prüfungsfragen zum Erwerb von Amateurfunkprüfungsbescheinigungen \n \n Änderungen: HTML Tags wurden aus den Fragen entfernt', style: TextStyle(fontStyle: FontStyle.italic)),
+                description: Semantics(
+                  link: true,
+                  label: "Bundesnetzagentur-Website zum Amateurfunk öffnen",
+                  child: GestureDetector(
+                    onTap: () => _launchURL('https://www.bundesnetzagentur.de/amateurfunk'),
+                    child: Text('www.bundesnetzagentur.de/amateurfunk \n \n Prüfungsfragen zum Erwerb von Amateurfunkprüfungsbescheinigungen \n \n Änderungen: HTML Tags wurden aus den Fragen entfernt', style: TextStyle(fontStyle: FontStyle.italic)),
+                  ),
                 ),
               ),
               SettingsTile(
                 title: Text(""),
-                description: GestureDetector(
-                  onTap: () => _launchURL('https://www.govdata.de/dl-de/by-2-0'),
-                  child: Text('Datenlizenz Deutschland – Namensnennung – Version 2.0 \n www.govdata.de/dl-de/by-2-0'),
+                description: Semantics(
+                  link: true,
+                  label: "Datenlizenz Deutschland – Namensnennung – Version 2.0 öffnen",
+                  child: GestureDetector(
+                    onTap: () => _launchURL('https://www.govdata.de/dl-de/by-2-0'),
+                    child: Text('Datenlizenz Deutschland – Namensnennung – Version 2.0 \n www.govdata.de/dl-de/by-2-0'),
+                  ),
                 ),
               ),
             ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:fuenfzigohm/helpers/packagesListing.dart';
 import 'package:fuenfzigohm/helpers/questionsLicenseNotice.dart';
 import 'package:fuenfzigohm/style/style.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 void main() {
@@ -89,6 +90,15 @@ class _PocketAppState extends State<PocketApp> {
               darkTheme: darkmode(),
               themeMode: ThemeMode.system,
               title: '50ohm-pocket',
+              locale: const Locale('de', 'DE'),
+              localizationsDelegates: const [
+                GlobalMaterialLocalizations.delegate,
+                GlobalWidgetsLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
+              ],
+              supportedLocales: const [
+                Locale('de', 'DE'),
+              ],
               home: Welcome(),
               routes: {
                 '/learn': (context) => Learningmodule(),

--- a/lib/screens/chapterSelection.dart
+++ b/lib/screens/chapterSelection.dart
@@ -27,9 +27,10 @@ class _LearningmoduleState extends State<Learningmodule> {
     bool courseOrdering = DatabaseWidget.of(context).settings_database.get("courseOrdering") ?? true;
     return Scaffold(
       appBar: AppBar(
-        title: SvgPicture.asset("assets/icons/ohm2.svg"),
+        title: SvgPicture.asset("assets/icons/ohm2.svg", semanticsLabel: "50 Ohm"),
         actions: [
           PopupMenuButton(
+            tooltip: "Menü öffnen",
             itemBuilder: (context) => [
               PopupMenuItem(
                 value: 2,
@@ -180,7 +181,7 @@ class _LearningmoduleState extends State<Learningmodule> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
-                  TextButton(
+                  ExcludeSemantics(child: TextButton(
                     onPressed: () {},
                     style: TextButton.styleFrom(
                       minimumSize: Size.fromHeight(100),
@@ -231,9 +232,12 @@ class _LearningmoduleState extends State<Learningmodule> {
                         ],
                       ),
                     ),
-                  ),
+                  )),
                   json.chaptersize(currentmainchapter) == 0
-                      ? LinearProgressIndicator(value: Databaseobj(context).read(JsonWidget.of(context).mainchapter, currentmainchapter, null))
+                      ? LinearProgressIndicator(
+                          value: Databaseobj(context).read(JsonWidget.of(context).mainchapter, currentmainchapter, null),
+                          semanticsLabel: "Lernfortschritt",
+                        )
                       : SizedBox(height: 8,),
 
                   chapterLesson(currentmainchapter, json),
@@ -259,9 +263,11 @@ class _LearningmoduleState extends State<Learningmodule> {
           margin: EdgeInsets.only(top: 10),
           child: Column(
             children: [
-              LinearProgressIndicator(value: Databaseobj(context).read(JsonWidget.of(context).mainchapter, chapter, subchapter), color: main_col,),
-              InkWell(
-                onTap:() async {
+              ExcludeSemantics(
+                child: LinearProgressIndicator(value: Databaseobj(context).read(JsonWidget.of(context).mainchapter, chapter, subchapter), color: main_col,),
+              ),
+              ListTile(
+                onTap: () async {
                   Navigator.of(context).push(
                     MaterialPageRoute(builder: (BuildContext materialcontext) => Question(context, [subchapter], chapter)),
                   ).then((value){
@@ -270,30 +276,31 @@ class _LearningmoduleState extends State<Learningmodule> {
                     }
                   });
                 },
-                child: ListTile(
-                  leading: Icon(starticon(json.chaptericon(chapter, subchapter))),
-                  title: Text(
-                    json.subchapter_name(chapter, subchapter),
-                    style: TextStyle(
-                        fontWeight: FontWeight.w500
-                    ),
-                  ),
-                  trailing: Container(
-                    padding: EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                    decoration: BoxDecoration(
-                      color: main_col.withOpacity(0.15),
-                      borderRadius: BorderRadius.circular(12),
-                      border: Border.all(
-                        color: main_col.withOpacity(0.3),
-                        width: 1,
+                leading: ExcludeSemantics(child: Icon(starticon(json.chaptericon(chapter, subchapter)))),
+                title: Text(
+                  json.subchapter_name(chapter, subchapter),
+                  style: TextStyle(fontWeight: FontWeight.w500),
+                ),
+                trailing: Semantics(
+                  label: "$questionCount Fragen",
+                  child: ExcludeSemantics(
+                    child: Container(
+                      padding: EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                      decoration: BoxDecoration(
+                        color: main_col.withOpacity(0.15),
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(
+                          color: main_col.withOpacity(0.3),
+                          width: 1,
+                        ),
                       ),
-                    ),
-                    child: Text(
-                      '$questionCount',
-                      style: TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.bold,
-                        color: main_col,
+                      child: Text(
+                        '$questionCount',
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.bold,
+                          color: main_col,
+                        ),
                       ),
                     ),
                   ),

--- a/lib/screens/completeLesson.dart
+++ b/lib/screens/completeLesson.dart
@@ -42,25 +42,30 @@ class _finishstate extends State<Finish>{
               ),
               Padding(
                 padding: const EdgeInsets.all(18.0),
-                child: AspectRatio(
-                  aspectRatio: 0.8,
-                  child: PieChart(
-                    PieChartData(
-                      sections: [
-                        PieChartSectionData(
-                          value: progress(),
-                          color: Colors.green,
-                          title: "richtig",
+                child: Semantics(
+                  label: "${progress().round()}% richtig, ${(100.0 - progress()).round()}% falsch",
+                  child: ExcludeSemantics(
+                    child: AspectRatio(
+                      aspectRatio: 0.8,
+                      child: PieChart(
+                        PieChartData(
+                          sections: [
+                            PieChartSectionData(
+                              value: progress(),
+                              color: Colors.green,
+                              title: "richtig",
+                            ),
+                            PieChartSectionData(
+                              value: 100.0 - progress(),
+                              color: Colors.red,
+                              title: "falsch",
+                            ),
+                          ]
                         ),
-                        PieChartSectionData(
-                          value: 100.0 - progress(),
-                          color: Colors.red,
-                          title: "falsch",
-                        ),
-                      ]
+                        swapAnimationDuration: Duration(milliseconds: 1500),
+                        swapAnimationCurve: Curves.linear,
+                      ),
                     ),
-                    swapAnimationDuration: Duration(milliseconds: 1500), // Optional
-                    swapAnimationCurve: Curves.linear, 
                   ),
                 ),
               ),

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -42,6 +42,7 @@ class _WelcomeState extends State<Welcome> {
                           alignment: Alignment.topCenter,
                           clipBehavior: Clip.hardEdge,
                           fit: BoxFit.fitWidth,
+                          excludeFromSemantics: true,
                         ),
                       ),
                     ),
@@ -70,7 +71,9 @@ class _WelcomeState extends State<Welcome> {
                     ),
                     Align(
                       alignment: Alignment.bottomCenter,
-                      child: InkWell(
+                      child: Semantics(
+                        button: true,
+                        child: InkWell(
                         onTap: () {
                           _pageController.animateToPage(1, duration: Duration(milliseconds: 200), curve: Curves.linear);
                         },
@@ -93,6 +96,7 @@ class _WelcomeState extends State<Welcome> {
                           ),
                         ),
                       ),
+                      ),
                     )
                   ],
                 ),
@@ -114,119 +118,134 @@ class _WelcomeState extends State<Welcome> {
                       },
                           child: Text("Ich habe schon eine Prüfung abgelegt.", style: TextStyle(fontSize: 18),)
                       ),
-                      InkWell(
-                        onTap: (){
-                          handleStart([1], context);
-                        },
-                        child: Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: Color(0xff47ABE8),
-                              borderRadius: BorderRadius.circular(15.0),
-                            ),
+                      Semantics(
+                        button: true,
+                        child: MergeSemantics(
+                          child: InkWell(
+                            onTap: (){
+                              handleStart([1], context);
+                            },
                             child: Padding(
-                              padding: const EdgeInsets.all(18.0),
-                              child: Column(
-                                children: [
-                                  Row(
-                                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              padding: const EdgeInsets.all(8.0),
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: Color(0xff47ABE8),
+                                  borderRadius: BorderRadius.circular(15.0),
+                                ),
+                                child: Padding(
+                                  padding: const EdgeInsets.all(18.0),
+                                  child: Column(
                                     children: [
-                                      Text("Klasse N", style: TextStyle(fontSize: 36, fontWeight: FontWeight.w800),),
-                                      Container(
-                                        decoration: BoxDecoration(
-                                          color: Color(0xff00008B),
-                                          borderRadius: BorderRadius.circular(15.0),
-                                        ),
-                                        child: Center(
-                                          child: Padding(
-                                            padding: const EdgeInsets.all(8.0),
-                                            child: Text(
-                                                "Neu",
-                                                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.white)
+                                      Row(
+                                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                        children: [
+                                          Text("Klasse N", style: TextStyle(fontSize: 36, fontWeight: FontWeight.w800),),
+                                          Container(
+                                            decoration: BoxDecoration(
+                                              color: Color(0xff00008B),
+                                              borderRadius: BorderRadius.circular(15.0),
+                                            ),
+                                            child: Center(
+                                              child: Padding(
+                                                padding: const EdgeInsets.all(8.0),
+                                                child: Text(
+                                                    "Neu",
+                                                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.white)
+                                                ),
+                                              ),
                                             ),
                                           ),
-                                        ),
+                                        ],
                                       ),
+                                      Row(
+                                        children: [
+                                          Expanded(
+                                              child: Text(
+                                                "Baue deine eigene Funkstation auf, experimentiere mit neuester Technik und knüpfte Kontakte weltweit. Erlebe grenzenlose Kommunikation und werde Teil einer aktiven Gemeinschaft, die die Zukunft des Amateurfunks gestaltet.",
+                                                style: TextStyle(fontSize: 17),
+                                              )),
+                                          ExcludeSemantics(child: Icon(Icons.arrow_forward_ios)),
+                                        ],
+                                      )
                                     ],
                                   ),
-                                  Row(
-                                    children: [
-                                      Expanded(
-                                          child: Text(
-                                            "Baue deine eigene Funkstation auf, experimentiere mit neuester Technik und knüpfte Kontakte weltweit. Erlebe grenzenlose Kommunikation und werde Teil einer aktiven Gemeinschaft, die die Zukunft des Amateurfunks gestaltet.",
-                                            style: TextStyle(fontSize: 17),
-                                          )),
-                                      Icon(Icons.arrow_forward_ios)
-                                    ],
-                                  )
-                                ],
+                                ),
                               ),
                             ),
                           ),
                         ),
                       ),
-                      InkWell(
-                        onTap: (){
-                          handleStart([1, 2], context);
-                        },
-                        child: Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: Color(0xffFE756C),
-                              borderRadius: BorderRadius.circular(15.0),
-                            ),
+                      Semantics(
+                        button: true,
+                        child: MergeSemantics(
+                          child: InkWell(
+                            onTap: (){
+                              handleStart([1, 2], context);
+                            },
                             child: Padding(
-                              padding: const EdgeInsets.all(18.0),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text("Klasse E", style: TextStyle(fontSize: 36, fontWeight: FontWeight.w800),),
-                                  Row(
+                              padding: const EdgeInsets.all(8.0),
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: Color(0xffFE756C),
+                                  borderRadius: BorderRadius.circular(15.0),
+                                ),
+                                child: Padding(
+                                  padding: const EdgeInsets.all(18.0),
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
                                     children: [
-                                      Expanded(
-                                          child: Text(
-                                            "Vertiefe deine Kenntnisse in Technik und Funkbetrieb, nimm an Amateurfunk-Wettbewerben teil und engagiere dich in der Ausbildung von neuen Funkamateuren.",
-                                            style: TextStyle(fontSize: 17),
-                                          )),
-                                      Icon(Icons.arrow_forward_ios)
+                                      Text("Klasse E", style: TextStyle(fontSize: 36, fontWeight: FontWeight.w800),),
+                                      Row(
+                                        children: [
+                                          Expanded(
+                                              child: Text(
+                                                "Vertiefe deine Kenntnisse in Technik und Funkbetrieb, nimm an Amateurfunk-Wettbewerben teil und engagiere dich in der Ausbildung von neuen Funkamateuren.",
+                                                style: TextStyle(fontSize: 17),
+                                              )),
+                                          ExcludeSemantics(child: Icon(Icons.arrow_forward_ios)),
+                                        ],
+                                      )
                                     ],
-                                  )
-                                ],
+                                  ),
+                                ),
                               ),
                             ),
                           ),
                         ),
                       ),
-                      InkWell(
-                        onTap: (){
-                          handleStart([1, 2, 3], context);
-                        },
-                        child: Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: Color(0xff3BB583),
-                              borderRadius: BorderRadius.circular(15.0),
-                            ),
+                      Semantics(
+                        button: true,
+                        child: MergeSemantics(
+                          child: InkWell(
+                            onTap: (){
+                              handleStart([1, 2, 3], context);
+                            },
                             child: Padding(
-                              padding: const EdgeInsets.all(18.0),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text("Klasse A", style: TextStyle(fontSize: 36, fontWeight: FontWeight.w800),),
-                                  Row(
+                              padding: const EdgeInsets.all(8.0),
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: Color(0xff3BB583),
+                                  borderRadius: BorderRadius.circular(15.0),
+                                ),
+                                child: Padding(
+                                  padding: const EdgeInsets.all(18.0),
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
                                     children: [
-                                      Expanded(
-                                          child: Text(
-                                            "Errichte deine eigene Amateurfunkstation mit hoher Sendeleistung, leite Funkkurse und bilde neue Funkamateure aus. Engagiere dich in der Forschung und Entwicklung neuer Funktechnologien und gestalte die Zukunft des Amateurfunks aktiv mit.",
-                                            style: TextStyle(fontSize: 17),
-                                          )),
-                                      Icon(Icons.arrow_forward_ios)
+                                      Text("Klasse A", style: TextStyle(fontSize: 36, fontWeight: FontWeight.w800),),
+                                      Row(
+                                        children: [
+                                          Expanded(
+                                              child: Text(
+                                                "Errichte deine eigene Amateurfunkstation mit hoher Sendeleistung, leite Funkkurse und bilde neue Funkamateure aus. Engagiere dich in der Forschung und Entwicklung neuer Funktechnologien und gestalte die Zukunft des Amateurfunks aktiv mit.",
+                                                style: TextStyle(fontSize: 17),
+                                              )),
+                                          ExcludeSemantics(child: Icon(Icons.arrow_forward_ios)),
+                                        ],
+                                      )
                                     ],
-                                  )
-                                ],
+                                  ),
+                                ),
                               ),
                             ),
                           ),

--- a/lib/screens/question.dart
+++ b/lib/screens/question.dart
@@ -13,6 +13,7 @@ import 'package:fuenfzigohm/style/style.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter/semantics.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 enum QuestionState{
@@ -118,17 +119,22 @@ class _Questionstate extends State<Question> with TickerProviderStateMixin {
                       ),
                     ),
                     SizedBox(width: 12),
-                    Container(
-                      padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                      decoration: BoxDecoration(
-                        color: main_col.withOpacity(0.2),
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: Text(
-                        "${questionkey + 1}/${questionorder.length}",
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w500,
+                    Semantics(
+                      label: "Frage ${questionkey + 1} von ${questionorder.length}",
+                      child: ExcludeSemantics(
+                        child: Container(
+                          padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                          decoration: BoxDecoration(
+                            color: main_col.withOpacity(0.2),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Text(
+                            "${questionkey + 1}/${questionorder.length}",
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
                         ),
                       ),
                     ),
@@ -194,7 +200,6 @@ class _Questionstate extends State<Question> with TickerProviderStateMixin {
                 child: Padding(
                   padding: EdgeInsets.only(bottom: 10, left: 8, right: 8),
                   child: ElevatedButton(
-                    autofocus: false,
                     style: buttonstyle(main_col),
                     onPressed: () {
                       if(state == QuestionState.answering && questionradio != null){
@@ -227,7 +232,7 @@ class _Questionstate extends State<Question> with TickerProviderStateMixin {
     return subsectionUrl(course, subsectionTitle) ?? 'https://50ohm.de';
   }
 
-  InteractiveViewer questionImage(BuildContext context, String url) {
+  Widget questionImage(BuildContext context, String url, {String semanticsLabel = "Diagramm"}) {
     List<String> illegalImages = ["BE207_q", "NF106_q", "BE209_q", "NF104_q", "NF102_q", "NF105_q", "BE208_q", "NE209_q", "NG302_q", "NF103_q", "NF101_q"];
     Widget image;
     double imageScaleWidth = min(MediaQuery.sizeOf(context).width * 0.8, 500);
@@ -262,11 +267,16 @@ class _Questionstate extends State<Question> with TickerProviderStateMixin {
           width: imageScaleWidth
       );
     };
-    return InteractiveViewer(
-      boundaryMargin: const EdgeInsets.all(20.0),
-      maxScale: 1.6,
-      panEnabled: false,
-      child: image,
+    return Semantics(
+      label: semanticsLabel,
+      child: ExcludeSemantics(
+        child: InteractiveViewer(
+          boundaryMargin: const EdgeInsets.all(20.0),
+          maxScale: 1.6,
+          panEnabled: false,
+          child: image,
+        ),
+      ),
     );
   }
   ListView radioSvgListBuilder() {
@@ -281,20 +291,24 @@ class _Questionstate extends State<Question> with TickerProviderStateMixin {
             decoration: BoxDecoration(
               color: i == highlighting ? questionColor : Colors.transparent,
             ),
-            child: RadioListTile(
-              fillColor: MaterialStateColor.resolveWith((states) => main_col),
-              activeColor: main_col,
-              enableFeedback: true,
-              groupValue: questionradio,
-              value: i,
-              onChanged: (var value) {
-                if(state == QuestionState.answering){
-                  setState(() {
-                    questionradio = i;
-                  });
-                }
-              },
-              title: questionImage(context, ShuffledAnswers[i]),
+            child: Semantics(
+              label: "Antwort ${i + 1} von 4",
+              selected: i == highlighting,
+              child: RadioListTile(
+                fillColor: MaterialStateColor.resolveWith((states) => main_col),
+                activeColor: main_col,
+                enableFeedback: true,
+                groupValue: questionradio,
+                value: i,
+                onChanged: (var value) {
+                  if(state == QuestionState.answering){
+                    setState(() {
+                      questionradio = i;
+                    });
+                  }
+                },
+                title: ExcludeSemantics(child: questionImage(context, ShuffledAnswers[i])),
+              ),
             ),
           );
         }
@@ -375,13 +389,27 @@ class _Questionstate extends State<Question> with TickerProviderStateMixin {
       };
     }
     if(correct){
-      _overlay(false);
+      _overlay(false, "Richtig!");
     }
     else{
-      _overlay(true);
+      final hasMath = Answers[0].contains(RegExp(r'\$[^$]+\$'));
+      final announcement = (imageQuestion || hasMath)
+          ? "Falsch."
+          : "Falsch. Die richtige Antwort ist: ${_plainText(Answers[0])}";
+      _overlay(true, announcement);
     }
   }
-  _overlay(bool wrong) {
+
+  String _plainText(String raw) {
+    return parse(raw).body?.text ?? raw;
+  }
+
+  _overlay(bool wrong, String announcement) {
+    SemanticsService.sendAnnouncement(
+      View.of(context),
+      announcement,
+      TextDirection.ltr,
+    );
 
     OverlayState? overlayState = Overlay.of(context);
 
@@ -422,7 +450,7 @@ class _Questionstate extends State<Question> with TickerProviderStateMixin {
                   child: Padding(
                     padding: EdgeInsets.only(bottom: 10, left: 8, right: 8),
                     child: ElevatedButton(
-                      autofocus: false,
+                      autofocus: true,
                       style: buttonstyle(wrong ? Colors.redAccent : Colors.green),
                       onPressed: (){
                         overlayEntry!.remove();

--- a/lib/screens/question.dart
+++ b/lib/screens/question.dart
@@ -405,11 +405,7 @@ class _Questionstate extends State<Question> with TickerProviderStateMixin {
   }
 
   _overlay(bool wrong, String announcement) {
-    SemanticsService.sendAnnouncement(
-      View.of(context),
-      announcement,
-      TextDirection.ltr,
-    );
+    SemanticsService.announce(announcement, TextDirection.ltr);
 
     OverlayState? overlayState = Overlay.of(context);
 

--- a/lib/screens/selectLearningPath.dart
+++ b/lib/screens/selectLearningPath.dart
@@ -20,100 +20,115 @@ class selectClass extends StatelessWidget{
             children: [
               Column(
                 children: [
-                  InkWell(
-                    onTap: (){
-                      handleStart([2], context);
-                    },
-                    child: Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: Color(0xffFE756C),
-                          borderRadius: BorderRadius.circular(15.0),
-                        ),
+                  Semantics(
+                    button: true,
+                    child: MergeSemantics(
+                      child: InkWell(
+                        onTap: (){
+                          handleStart([2], context);
+                        },
                         child: Padding(
-                          padding: const EdgeInsets.all(18.0),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text("Upgrade von N auf E", style: TextStyle(fontSize: 30, fontWeight: FontWeight.w700),),
-                              Row(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Color(0xffFE756C),
+                              borderRadius: BorderRadius.circular(15.0),
+                            ),
+                            child: Padding(
+                              padding: const EdgeInsets.all(18.0),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  Expanded(
-                                      child: Text(
-                                        "Du hast schon deine N Zulassung? Super! Starte heute mit deinen Vorbereitungen auf die Klasse E.",
-                                        style: TextStyle(fontSize: 17),
-                                      )),
-                                  Icon(Icons.arrow_forward_ios)
+                                  Text("Upgrade von N auf E", style: TextStyle(fontSize: 30, fontWeight: FontWeight.w700),),
+                                  Row(
+                                    children: [
+                                      Expanded(
+                                          child: Text(
+                                            "Du hast schon deine N Zulassung? Super! Starte heute mit deinen Vorbereitungen auf die Klasse E.",
+                                            style: TextStyle(fontSize: 17),
+                                          )),
+                                      ExcludeSemantics(child: Icon(Icons.arrow_forward_ios)),
+                                    ],
+                                  )
                                 ],
-                              )
-                            ],
+                              ),
+                            ),
                           ),
                         ),
                       ),
                     ),
                   ),
-                  InkWell(
-                    onTap: (){
-                      handleStart([3], context);
-                    },
-                    child: Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: Color(0xff3BB583),
-                          borderRadius: BorderRadius.circular(15.0),
-                        ),
+                  Semantics(
+                    button: true,
+                    child: MergeSemantics(
+                      child: InkWell(
+                        onTap: (){
+                          handleStart([3], context);
+                        },
                         child: Padding(
-                          padding: const EdgeInsets.all(18.0),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text("Upgrade von E auf A", style: TextStyle(fontSize: 30, fontWeight: FontWeight.w700),),
-                              Row(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Color(0xff3BB583),
+                              borderRadius: BorderRadius.circular(15.0),
+                            ),
+                            child: Padding(
+                              padding: const EdgeInsets.all(18.0),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  Expanded(
-                                      child: Text(
-                                        "Du hast deine E Zulassung? Super! Starte heute mit deinen Vorbereitungen auf die Klasse A.",
-                                        style: TextStyle(fontSize: 17),
-                                      )),
-                                  Icon(Icons.arrow_forward_ios)
+                                  Text("Upgrade von E auf A", style: TextStyle(fontSize: 30, fontWeight: FontWeight.w700),),
+                                  Row(
+                                    children: [
+                                      Expanded(
+                                          child: Text(
+                                            "Du hast deine E Zulassung? Super! Starte heute mit deinen Vorbereitungen auf die Klasse A.",
+                                            style: TextStyle(fontSize: 17),
+                                          )),
+                                      ExcludeSemantics(child: Icon(Icons.arrow_forward_ios)),
+                                    ],
+                                  )
                                 ],
-                              )
-                            ],
+                              ),
+                            ),
                           ),
                         ),
                       ),
                     ),
                   ),
-                  InkWell(
-                    onTap: (){
-                      handleStart([2, 3], context);
-                    },
-                    child: Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: Color(0xff47ABE8),
-                          borderRadius: BorderRadius.circular(15.0),
-                        ),
+                  Semantics(
+                    button: true,
+                    child: MergeSemantics(
+                      child: InkWell(
+                        onTap: (){
+                          handleStart([2, 3], context);
+                        },
                         child: Padding(
-                          padding: const EdgeInsets.all(18.0),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text("Upgrade von N auf A", style: TextStyle(fontSize: 30, fontWeight: FontWeight.w700),),
-                              Row(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Color(0xff47ABE8),
+                              borderRadius: BorderRadius.circular(15.0),
+                            ),
+                            child: Padding(
+                              padding: const EdgeInsets.all(18.0),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  Expanded(
-                                      child: Text(
-                                        "Du hast deine N Zulassung? Super! Starte heute mit deinen Vorbereitungen auf die Klasse A.",
-                                        style: TextStyle(fontSize: 17),
-                                      )),
-                                  Icon(Icons.arrow_forward_ios)
+                                  Text("Upgrade von N auf A", style: TextStyle(fontSize: 30, fontWeight: FontWeight.w700),),
+                                  Row(
+                                    children: [
+                                      Expanded(
+                                          child: Text(
+                                            "Du hast deine N Zulassung? Super! Starte heute mit deinen Vorbereitungen auf die Klasse A.",
+                                            style: TextStyle(fontSize: 17),
+                                          )),
+                                      ExcludeSemantics(child: Icon(Icons.arrow_forward_ios)),
+                                    ],
+                                  )
                                 ],
-                              )
-                            ],
+                              ),
+                            ),
                           ),
                         ),
                       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
   cupertino_icons: ^1.0.2
   json_annotation: ^4.8.1


### PR DESCRIPTION
Mit dem PR hab ich mal die Basis-Funktionalität der der 50 Ohm App mit Screenreadern etwas verbessert:

Verbesserungen:

- Setzen von Flutter Konfigurationen, damit die Texte innerhalb der App auf Deutsch vorgelesen werden.
- Semantische Improvements innerhalb der Hauptscreens und dessen Elemente, damit Fragen, Antworten und andere Optionen zumindest als Basisversion besser vorgelesen werden. (Beinhaltet Intro/Lernpfad/Lizenz-Notiz/Kapitelselektion/Sektionsabschluss und Fragen-Screens)

Zukünftige Improvements:
(Dies soll erst einmal eine Basisversion sein, damit die grundsätzliche Funktionalität erst einmal gegeben ist...)

- Weitere semantische Improvements in anderen Screens.

- Bessere alt-Beschreibungen für Antworten mit Formeln oder Bildern

- Bessere generelle Semantik